### PR TITLE
Feature compose signature

### DIFF
--- a/test/profile-tests.el
+++ b/test/profile-tests.el
@@ -116,6 +116,35 @@
      "Was looking at %s"
      (buffer-substring-no-properties (point) (point-at-eol)))))
 
+(ert-deftest profile-tests-change-signature-in-compose-with-newline ()
+  (with-current-buffer (get-buffer-create "*ert-profilel-w-newline*")
+    (insert "From: foo\n--text follows this line--\ncontent\n\n-- \nold signature")
+    (setq mu4e-compose-signature "new signature")
+    (profile--change-signature-in-compose)
+    (message-goto-signature)
+    (forward-line -3)
+    (message-beginning-of-line)
+    (should (looking-at "content\n\n-- \nnew signature\n"))))
+
+(ert-deftest profile-tests-change-signature-in-compose-without-newline ()
+  (with-current-buffer (get-buffer-create "*ert-profilel-wo-newline*")
+    (insert "From: foo\n--text follows this line--\ncontent\n-- \nold signature")
+    (setq mu4e-compose-signature "new signature")
+    (profile--change-signature-in-compose)
+    (message-goto-signature)
+    (forward-line -2)
+    (message-beginning-of-line)
+    (should (looking-at "content\n-- \nnew signature\n"))))
+
+(ert-deftest profile-tests-change-signature-in-compose-without-signature ()
+  (with-current-buffer (get-buffer-create "*ert-profilel-wo-signature*")
+    (insert "From: foo\n--text follows this line-- \ncontent")
+    (setq mu4e-compose-signature "new signature")
+    (profile--change-signature-in-compose)
+    (message-goto-signature)
+    (message-beginning-of-line)
+    (should (looking-at "new signature"))))
+
 (provide 'profile-tests)
 
 ;;; profile-tests.el ends here


### PR DESCRIPTION
As you recommended, I replaced `previous-line` with `forward-line` and included a `boundp` check before using `mu4e-compose-signature`.
